### PR TITLE
Move cli/farm into wiki-node

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-// **server.js**
-
-require('coffee-script');
-require('wiki-server/lib/cli');

--- a/cli.coffee
+++ b/cli.coffee
@@ -1,0 +1,110 @@
+# **cli.coffee** command line interface for the
+# Smallest-Federated-Wiki express server
+
+path = require 'path'
+
+optimist = require 'optimist'
+cc = require 'config-chain'
+glob = require 'glob'
+server = require 'wiki-server'
+
+farm = require './farm'
+
+getUserHome = ->
+  process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE
+
+# Handle command line options
+
+argv = optimist
+  .usage('Usage: $0')
+  .options('url',
+    alias     : 'u'
+    describe  : 'Important: Your server URL, used as Persona audience during verification'
+  )
+  .options('port',
+    alias     : 'p'
+    describe  : 'Port'
+  )
+  .options('data',
+    alias     : 'd'
+    describe  : 'location of flat file data'
+  )
+  .options('root',
+    alias     : 'r'
+    describe  : 'Application root folder'
+  )
+  .options('farm',
+    alias     : 'f'
+    describe  : 'Turn on the farm?'
+  )
+  .options('farmPort',
+    alias     : 'F'
+    describe  : 'Port to start farm servers on.'
+  )
+  .options('home',
+    describe  : 'The page to go to instead of index.html'
+  )
+  .options('host',
+    alias     : 'o'
+    describe  : 'Host to accept connections on, falsy == any'
+  )
+  .options('id',
+    describe  : 'Set the location of the open id file'
+  )
+  .options('database',
+    describe  : 'JSON object for database config'
+  )
+  .options('test',
+    boolean   : true
+    describe  : 'Set server to work with the rspec integration tests'
+  )
+  .options('help',
+    alias     : 'h'
+    boolean   : true
+    describe  : 'Show this help info and exit'
+  )
+  .options('config',
+    alias     : 'conf'
+    describe  : 'Optional config file.'
+  )
+  .options('version',
+    alias     : 'v'
+    describe  : 'Optional config file.'
+  )
+  .argv
+
+config = cc(argv,
+  argv.config,
+  'config.json',
+  path.join(__dirname, '..', 'config.json'),
+  cc.env('wiki_'),
+    farmPort: 40000
+    port: 3000
+    root: path.dirname(require.resolve('wiki-server'))
+    home: 'welcome-visitors'
+    data: path.join(getUserHome(), '.wiki') # see also defaultargs
+    packageDir: path.resolve('./node_modules')
+).store
+
+# If h/help is set print the generated help message and exit.
+if argv.help
+  optimist.showHelp()
+# If v/version is set print the version of the wiki components and exit.
+else if argv.version
+  console.log('wiki: ' + require('./package').version)
+  console.log('wiki-server: ' + require('wiki-server/package').version)
+  console.log('wiki-client: ' + require('wiki-client/package').version)
+  glob 'wiki-plugin-*', {cwd: config.packageDir}, (e, plugins) ->
+    plugins.map (plugin) ->
+      console.log(plugin + ': ' + require(plugin + '/package').version)
+
+else if argv.test
+  console.log "WARNING: Server started in testing mode, other options ignored"
+  server({port: 33333, data: path.join(argv.root, 'spec', 'data')})
+# If f/farm is set call../lib/farm.coffee with argv object, else call
+# ../lib/server.coffee with argv object.
+else if config.farm
+  console.log('Wiki starting in Farm mode, navigate to a specific server to start it.')
+  farm(config)
+else
+  server(config)

--- a/farm.coffee
+++ b/farm.coffee
@@ -1,0 +1,62 @@
+# **farm.coffee**
+# The farm module works by putting a bouncy host based proxy
+# in front of servers that it creates
+
+path = require 'path'
+
+bouncy = require 'bouncy'
+
+server = require 'wiki-server'
+
+module.exports = exports = (argv) ->
+  # Map incoming hosts to their wiki's port
+  hosts = {}
+  # Keep an array of servers that are currently active
+  runningServers = []
+
+  # Get the next available port.
+  nextport = do ->
+    # Start port as farm port -1 so it returns the original farm
+    # port the first time it is used.
+    # TODO: Call out to the os to make sure we return an open and valid port.
+    port = argv.farmPort - 1
+    -> port += 1
+
+  # Bouncy watches for incoming requests on the listen port at the bottom,
+  # and passes them to the callback it's called with,
+  # redirecting the requests at the port specified when
+  # the bounce function is called.
+  bouncy( (req, bounce) ->
+    # If the incoming request has a host, asign it to incHost
+    # otherwise do nothing and return.
+    if req.headers?.host
+      incHost = req.headers.host
+    else
+      return
+
+    # If the host starts with "www." treat it the same as if it didn't
+    if incHost[0..3] is "www."
+      incHost = incHost[4..]
+    # if we already have a port for this host, forward the request to it.
+    if hosts[incHost]
+      bounce(argv.host, hosts[incHost])
+    else
+      hosts[incHost] = nextport()
+      # Create a new options object, copy over the options used to start the
+      # farm, and modify them to make sense for servers spawned from the farm.
+      newargv = {}
+      for key, value of argv
+        newargv[key] = value
+      newargv.port = hosts[incHost]
+      newargv.data = if argv.data
+        path.join(argv.data, incHost.split(':')[0])
+      else
+        path.join(argv.root, 'data', incHost.split(':')[0])
+      newargv.url = "http://#{incHost}"
+      # Create a new server, add it to the list of servers, and
+      # once it's ready send the request to it.
+      local = server(newargv)
+      runningServers.push(local)
+      local.once "listening", ->
+        bounce(argv.host, hosts[incHost])
+  ).listen(argv.port, argv.host)

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "wiki",
   "version": "0.2.0",
-  "bin": {
-    "wiki": "./bin/server.js"
-  },
+  "bin": "./index.js",
   "description": "Federated Wiki",
   "author": {
     "name": "Paul Rodwell",
@@ -12,8 +10,12 @@
   },
   "license": "MIT",
   "dependencies": {
+    "bouncy": "3.2",
     "coffee-script": "1.6.3",
     "coffee-trace": "~1.4.0",
+    "config-chain": "1.1",
+    "glob": "4.0",
+    "optimist": "0.6",
     "wiki-server": "0.1",
     "wiki-client": "0.2",
     "wiki-plugin-activity": "0.1",
@@ -54,7 +56,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "start": "node bin/server.js"
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes the packageDir problem @WardCunningham mentions in wiki-node-server issue #65 by putting the command line startup scripts with the place they are required, and adding a reasonable default for packageDir. Corresponding change in wiki-node-server pr 66 
