### PR TITLE
add video and html plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "wiki-plugin-federatedwiki": "0.1",
     "wiki-plugin-force": "0.1",
     "wiki-plugin-future": "0.1",
+    "wiki-plugin-html": "*",
     "wiki-plugin-image": "0.1",
     "wiki-plugin-line": "0.1",
     "wiki-plugin-linkmap": "0.1",
@@ -52,7 +53,8 @@
     "wiki-plugin-rollup": "0.1",
     "wiki-plugin-scatter": "0.1",
     "wiki-plugin-twadio": "0.1",
-    "wiki-plugin-txtzyme": "0.1"
+    "wiki-plugin-txtzyme": "0.1",
+    "wiki-plugin-video": "*"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This adds the html and video plugins to the package.json so that they will be installed with the npm wiki package. The video plugin is assumed to be present when one drops a video on the factory plugin. If it isn't present, nothing too ugly happens but you don't see embedded video.

Prerequisite:
- This pull assumes that the wiki-plugin-html javascript has been packaged. 
  https://github.com/fedwiki/wiki-plugin-html/issues/3

Post requisite:
- Once the video plugin is available then the drag & drop video has something to make. https://github.com/fedwiki/wiki-client/pull/48
- Broad deployment of video & html plugins enable dealing with proper xss protection. https://github.com/fedwiki/wiki-client/issues/46
