### PR TITLE
add fig.yml and Dockerfile to ease testing and development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:0.10-slim
+
+ADD . /usr/src/app
+WORKDIR /usr/src/app
+RUN npm install
+
+EXPOSE 3000

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -135,6 +135,15 @@ The leveldb datastore allows for a graceful upgrade path. If a page is not found
 }
 ```
 
+### Run Wiki in Docker containers with different storage backends
+
+[Fig](http://www.fig.sh/install.html) allows to easily spin up docker containers with multiple wiki apps, couchdb and redis storage. It is configured through `fig.yml`. By uncommenting the redis and or couchdb paragraghs in `fig.yml` more containers can be started.
+    
+     $ fig up
+
+Visit $dockerhost:3000 to see your wiki.
+On OsX $dockerhost can be determined by running: `boot2docker ip` . On Linux the containers bind to 0.0.0.0
+The wiki-node source directory gets mounted into the app containers under /usr/src/app
 
 
 ## Participation

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,45 @@
+# this is a fig configuration file http://www.fig.sh
+# http://www.fig.sh/install.html
+#
+# run fig up
+
+web:
+  build: .
+  command: "node index.js --autoseed --farm"
+  ports:
+   - "3000:3000"
+   - "4000:4000"
+  volumes:
+   - .:/usr/src/app
+
+## uncomment to start additional container with differen storage backend
+#
+#webredis:
+#  build: .
+#  command: "node index.js --autoseed --database '{\"type\":\"redis\",\"host\":\"redis\"}'"
+#  ports:
+#   - "3001:3001"
+#  volumes:
+#   - .:/usr/src/app    
+#  environment:
+#   - wiki_port=3001
+#  links:
+#   - redis
+
+#redis:
+#  image: redis 
+
+#webcouch:
+#  build: .
+#  command: "node index.js --autoseed --database '{\"type\":\"couchdb\",\"host\":\"couchdb\"}'"
+#  ports:
+#   - "3002:3002"
+#  volumes:
+#   - .:/usr/src/app    
+#  environment:
+#   - wiki_port=3002
+#  links:
+#   - couchdb
+
+#couchdb:
+#  image: klaemo/couchdb 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,10 @@
     "wiki-plugin-txtzyme": "0.1",
     "wiki-plugin-video": "*"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "wiki-storage-couchdb": "0.0.1",
+    "wiki-storage-redis": "0.0.2"    
+  },
   "scripts": {
     "start": "node index.js"
   },


### PR DESCRIPTION
I would like to contribute a [fig.yml](http://www.fig.sh) and Dockerfile
It allows to spin up multiple docker containers with the wiki app.
Also allows to add redis and couchdb [...] containers to the mix and run these with wiki(0-conf)
It provides a reproducible development and even some day production ready environment.

I would also be possible to test farming/federation among several app containers.
interested? PR on the way
