### PR TITLE
add markdown plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "wiki-plugin-linkmap": "0.1",
     "wiki-plugin-logwatch": "0.1",
     "wiki-plugin-map": "0.1",
+    "wiki-plugin-markdown": "0.1",
     "wiki-plugin-mathjax": "0.1",
     "wiki-plugin-metabolism": "0.1",
     "wiki-plugin-method": "0.1",


### PR DESCRIPTION
This pull request adds the new Markdown plugin. That plugin will need to be published to npm first.

https://github.com/fedwiki/wiki-plugin-markdown

We've taken our guidance from the github guide. Unimplemented features or under-implemented features could appear or improve at a later date.

https://guides.github.com/features/mastering-markdown/

The About page describes the plugin as follows.

![image](https://cloud.githubusercontent.com/assets/12127/5425898/4aa7f068-82e2-11e4-9ebd-e2fa33437961.png)
