### PR TITLE
Implicit bin name has problems with scoped publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki",
   "version": "0.7.0",
-  "bin": "./index.js",
+  "bin": { "wiki": "./index.js"},
   "description": "Federated Wiki",
   "author": {
     "name": "Paul Rodwell",


### PR DESCRIPTION
Adding the explicit label to the binary means that if we publish as a scoped package for configuration reasons we can use it under the name 'wiki'.