### PR TITLE
Paul90/scoped dependency fix

### DIFF
--- a/cli.coffee
+++ b/cli.coffee
@@ -91,7 +91,7 @@ argv = optimist
   )
   .options('version',
     alias     : 'v'
-    describe  : 'Show version number and exit'
+    describe  : 'Show version of wiki and wiki components, and exit'
   )
   .argv
 
@@ -113,11 +113,10 @@ if argv.help
 # If v/version is set print the version of the wiki components and exit.
 else if argv.version
   console.log('wiki: ' + require('./package').version)
-  console.log('wiki-server: ' + require('wiki-server/package').version)
-  console.log('wiki-client: ' + require('wiki-client/package').version)
-  glob 'wiki-plugin-*', {cwd: config.packageDir}, (e, plugins) ->
-    plugins.map (plugin) ->
-      console.log(plugin + ': ' + require(plugin + '/package').version)
+
+  # print version of each of the 'wiki' components
+  for c, v of wikiModules when c.indexOf('wiki') > -1
+    console.log(c + ': ' + require(c + '/package').version)
 
 else if argv.test
   console.log "WARNING: Server started in testing mode, other options ignored"

--- a/cli.coffee
+++ b/cli.coffee
@@ -18,8 +18,11 @@ glob = require 'glob'
 wikiModules = require('./package').dependencies
 
 # require server, even if it is a scoped module
-for c, v of wModules when c.indexOf('wiki-server') > -1
-  server = require c
+if 'wiki-server' in wikiModules
+  server = require 'wiki-server'
+else
+  for c, v of wikiModules when c.indexOf('wiki-server') > -1
+    server = require c
 
 farm = require './farm'
 

--- a/cli.coffee
+++ b/cli.coffee
@@ -14,7 +14,12 @@ path = require 'path'
 optimist = require 'optimist'
 cc = require 'config-chain'
 glob = require 'glob'
-server = require 'wiki-server'
+
+wikiModules = require('./package').dependencies
+
+# require server, even if it is a scoped module
+for c, v of wModules when c.indexOf('wiki-server') > -1
+  server = require c
 
 farm = require './farm'
 

--- a/farm.coffee
+++ b/farm.coffee
@@ -17,8 +17,11 @@ http = require 'http'
 wikiModules = require('./package').dependencies
 
 # require server, even if it is a scoped module
-for c, v of wModules when c.indexOf('wiki-server') > -1
-  server = require c
+if 'wiki-server' in wikiModules
+  server = require 'wiki-server'
+else
+  for c, v of wikiModules when c.indexOf('wiki-server') > -1
+    server = require c
 
 
 module.exports = exports = (argv) ->

--- a/farm.coffee
+++ b/farm.coffee
@@ -14,7 +14,12 @@ path = require 'path'
 
 http = require 'http'
 
-server = require 'wiki-server'
+wikiModules = require('./package').dependencies
+
+# require server, even if it is a scoped module
+for c, v of wModules when c.indexOf('wiki-server') > -1
+  server = require c
+
 
 module.exports = exports = (argv) ->
   # Map incoming hosts to their wiki's port


### PR DESCRIPTION
A possible route for handling scoped packages, starting with `wiki-server` at this level.

Retrieves the dependencies from `package.json`, and uses that to drive the output from version.

Is there a better way of doing the require if a scoped version of `wiki-server` is being used?