### PR TITLE
Modularizing Security

### DIFF
--- a/cli.coffee
+++ b/cli.coffee
@@ -52,8 +52,8 @@ argv = optimist
     alias     : 'o'
     describe  : 'Host to accept connections on, falsy == any'
   )
-  .options('security',
-    describe  : 'JSON object for security config'
+  .options('security_type',
+    describe  : 'The security plugin to use, see documentation for additional parameters'
   )
   .options('id',
     describe  : 'Set the location of the Persona identity file'
@@ -101,7 +101,7 @@ config = cc(argv,
     port: 3000
     root: path.dirname(require.resolve('wiki-server'))
     home: 'welcome-visitors'
-    security: '{"type": "persona"}'
+    security_type: 'persona'
     data: path.join(getUserHome(), '.wiki') # see also defaultargs
     packageDir: path.resolve(path.join(__dirname, 'node_modules'))
 ).store

--- a/cli.coffee
+++ b/cli.coffee
@@ -52,6 +52,9 @@ argv = optimist
     alias     : 'o'
     describe  : 'Host to accept connections on, falsy == any'
   )
+  .options('security',
+    describe  : 'JSON object for security config'
+  )
   .options('id',
     describe  : 'Set the location of the open id file'
   )
@@ -98,6 +101,7 @@ config = cc(argv,
     port: 3000
     root: path.dirname(require.resolve('wiki-server'))
     home: 'welcome-visitors'
+    security: 'persona'
     data: path.join(getUserHome(), '.wiki') # see also defaultargs
     packageDir: path.resolve(path.join(__dirname, 'node_modules'))
 ).store

--- a/cli.coffee
+++ b/cli.coffee
@@ -101,7 +101,7 @@ config = cc(argv,
     port: 3000
     root: path.dirname(require.resolve('wiki-server'))
     home: 'welcome-visitors'
-    security: 'persona'
+    security: '{"type": "persona"}'
     data: path.join(getUserHome(), '.wiki') # see also defaultargs
     packageDir: path.resolve(path.join(__dirname, 'node_modules'))
 ).store

--- a/cli.coffee
+++ b/cli.coffee
@@ -114,6 +114,9 @@ else if argv.version
   console.log('wiki: ' + require('./package').version)
   console.log('wiki-server: ' + require('wiki-server/package').version)
   console.log('wiki-client: ' + require('wiki-client/package').version)
+  glob 'wiki-security-*', {cwd: config.packageDir}, (e, plugins) ->
+    plugins.map (plugin) ->
+      console.log(plugin + ": " + require(plugin + "/package").version)
   glob 'wiki-plugin-*', {cwd: config.packageDir}, (e, plugins) ->
     plugins.map (plugin) ->
       console.log(plugin + ': ' + require(plugin + '/package').version)

--- a/cli.coffee
+++ b/cli.coffee
@@ -56,7 +56,7 @@ argv = optimist
     describe  : 'JSON object for security config'
   )
   .options('id',
-    describe  : 'Set the location of the open id file'
+    describe  : 'Set the location of the Persona identity file'
   )
   .options('database',
     describe  : 'JSON object for database config'

--- a/farm.coffee
+++ b/farm.coffee
@@ -57,10 +57,10 @@ module.exports = exports = (argv) ->
 
       # do deep copy, needed for database configuration for instance
       copy = (map) ->
-          clone  = {}
-          for key, value of map
-            clone[key] = if typeof value == "object" then copy(value) else value
-          clone
+        clone  = {}
+        for key, value of map
+          clone[key] = if typeof value == "object" then copy(value) else value
+        clone
 
       newargv = copy argv
 


### PR DESCRIPTION
To make it easier to support alternative authentication schemes, we add support security plug-in.

Here we add a security parameter, and set an initial default to use Mozilla Persona. Moving the previous built-in Mozilla Persona authentication into a plug-in, see [fedwiki/wiki-security-persona](/fedwiki/wiki-security-persona).

We also update the wiki-server, and wiki-client, see pull requests fedwiki/wiki-server#110, and fedwiki/wiki-client#139

To aid testing of this change, *beta* tagged versions of these three npm packages have been created which can be installed by running `npm install wiki@beta`.

As well as providing Mozilla Persona, a very basic security scheme is also provide as part of the `wiki-server`. This does not provide the ability to login making any claimed sites read-only while any unclaimed sites can be edited by anybody.