### PR TITLE
Tell wiki-server we are up and running, in farm mode

### DIFF
--- a/cli.coffee
+++ b/cli.coffee
@@ -45,6 +45,9 @@ argv = optimist
     alias     : 'f'
     describe  : 'Turn on the farm?'
   )
+  .options('admin',
+    describe  : 'Wiki server administrator identity'
+  )
   .options('home',
     describe  : 'The page to go to instead of index.html'
   )

--- a/cli.coffee
+++ b/cli.coffee
@@ -133,5 +133,5 @@ else
   app = server(config)
   app.on 'owner-set', (e) ->
     serv = app.listen app.startOpts.port, app.startOpts.host
-    console.log "Smallest Federated Wiki server listening on", app.startOpts.port, "in mode:", app.settings.env
+    console.log "Federated Wiki server listening on", app.startOpts.port, "in mode:", app.settings.env
     app.emit 'running-serv', serv

--- a/farm.coffee
+++ b/farm.coffee
@@ -84,6 +84,7 @@ module.exports = exports = (argv) ->
           server.startOpts.neighbors = neighbors
 
       local.once "owner-set", ->
+        local.emit 'running-serv', farmServ
         hosts[incHost](req, res)
 
   runningFarmServ = farmServ.listen(argv.port, argv.host)

--- a/package.json
+++ b/package.json
@@ -53,8 +53,6 @@
     "wiki-plugin-html": "0.2",
     "wiki-plugin-image": "0.2",
     "wiki-plugin-line": "0.3",
-    "wiki-plugin-linkmap": "0.2",
-    "wiki-plugin-logwatch": "0.2",
     "wiki-plugin-map": "0.2",
     "wiki-plugin-markdown": "0.2",
     "wiki-plugin-mathjax": "0.2",
@@ -62,7 +60,6 @@
     "wiki-plugin-method": "0.2",
     "wiki-plugin-pagefold": "0.2",
     "wiki-plugin-paragraph": "0.2",
-    "wiki-plugin-parse": "0.2",
     "wiki-plugin-pushpin": "0.3",
     "wiki-plugin-radar": "0.3",
     "wiki-plugin-reduce": "0.2",
@@ -73,8 +70,6 @@
     "wiki-plugin-scatter": "0.3",
     "wiki-plugin-search": "0.0.8",
     "wiki-plugin-transport": "0.0.5",
-    "wiki-plugin-twadio": "0.2",
-    "wiki-plugin-txtzyme": "0.2",
     "wiki-plugin-video": "0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
When running in farm mode we neglected to emit `running-serv` once the owner has been set. As a result a number of processes in wiki-server that don't get performed until the server is running never happen. This includes starting the server component of any plugins that have one.

Also see fedwiki/wiki-server#115