### PR TITLE
Add electron experiment. (Don't merge)

### DIFF
--- a/electron-frame.html
+++ b/electron-frame.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style type="text/css">
+  html, body, webview { margin: 0; padding: 0; width: 100%; height: 100%; }
+</style>
+
+<body>
+  <webview src="http://localhost:3000"></webview>
+</body>

--- a/electron-splash.html
+++ b/electron-splash.html
@@ -4,5 +4,7 @@
 </style>
 
 <body>
-  <webview src="http://localhost:3333/view/welcome-visitors"></webview>
+  <center>
+  	<h1>Welcome to<br>Electron Wiki</h1>
+  </center>
 </body>

--- a/electron-wiki.js
+++ b/electron-wiki.js
@@ -1,10 +1,22 @@
 var app = require('app')
 var BrowserWindow = require('browser-window')
-var server = require('child_process').fork('./index.js')
+var server = require('child_process').fork('./index.js', ['-p', '3333'])
 
 app.on('ready', function () {
-  var browser = new BrowserWindow({ width: 1024, height: 768 })
-  browser.loadURL('file://' + __dirname + '/electron-frame.html')
+  var browser = new BrowserWindow({ width: 1024, height: 768})
+  browser.loadURL('file://' + __dirname + '/electron-splash.html')
+  setTimeout(start, 5000)
+  setTimeout(reload, 7000)
+
+  function start () {
+    console.log('start')
+    browser.loadURL('file://' + __dirname + '/electron-frame.html')
+  }
+
+  function reload () {
+    console.log('reload')
+    browser.reload()
+  }
 })
 
 app.on('will-quit', function () {

--- a/electron-wiki.js
+++ b/electron-wiki.js
@@ -1,0 +1,12 @@
+var app = require('app')
+var BrowserWindow = require('browser-window')
+var server = require('child_process').fork('./index.js')
+
+app.on('ready', function () {
+  var browser = new BrowserWindow({ width: 1024, height: 768 })
+  browser.loadURL('file://' + __dirname + '/electron-frame.html')
+})
+
+app.on('will-quit', function () {
+  server.kill()
+})

--- a/package.json
+++ b/package.json
@@ -73,11 +73,13 @@
     "wiki-plugin-video": "0.2"
   },
   "devDependencies": {
+    "electron-prebuilt": "^0.36.7",
     "grunt": "~0.4",
     "grunt-git-authors": "~3"
   },
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "electron-wiki": "electron electron-wiki.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This runs wiki inside of electron, to see what advantages that gives us.

Right now you have to open dev tools and refresh to see the window.

To test it out, checkout the branch, `npm install` and then you can `npm run electron-wiki`

![image](https://cloud.githubusercontent.com/assets/357596/13037050/51c4c6dc-d32c-11e5-97eb-29f9cf933dcb.png)
