### PR TITLE
remove experimental efficiency plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "wiki-plugin-chart": "0.3",
     "wiki-plugin-code": "0.2",
     "wiki-plugin-data": "0.2",
-    "wiki-plugin-efficiency": "0.2",
     "wiki-plugin-factory": "0.2",
     "wiki-plugin-favicon": "0.2",
     "wiki-plugin-federatedwiki": "0.2",


### PR DESCRIPTION
Moved experimental twadio and efficiency plugins out of fedwiki org. Adjusting package.json accordingly.

http://ward.asia.wiki.org/plugin-catalog.html