### PR TITLE
Replace 'fig' with 'docker-compose'

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -149,19 +149,19 @@ The Redis datastore allows for a graceful upgrade path. If a page is not found i
 
 ### Run Wiki in Docker containers with different storage backends
 
-[Fig](http://www.fig.sh/install.html) allows to easily spin up docker containers with multiple wiki apps, couchdb and redis storage.
-It is configured through `fig.yml`. By uncommenting the redis and or couchdb paragraghs in `fig.yml` more containers can be started.
+[docker-compose](https://docs.docker.com/compose/) allows to easily spin up docker containers with multiple wiki apps, couchdb and redis storage.
+It is configured through `docker-compose.yml`. By uncommenting the redis and or couchdb paragraghs in `docker-compose.yml` more containers can be started.
 
-     $ fig up
+     $ docker-compose up -d
 
 If you are not installing the wiki components locally you will need to build the app container by running:
 
-     $ fig build
-     $ fig run web npm install
-     $ fig up
+     $ docker-compose build
+     $ docker-compose run web npm install
+     $ docker-compose up -d
 
 Visit $dockerhost:3000 to see your wiki.
-On OsX $dockerhost can be determined by running: `boot2docker ip` . On Linux the containers bind to 0.0.0.0
+On OSX $dockerhost can be determined by running: `boot2docker ip`. In case you are using [DLite](https://github.com/nlf/dlite) on OSX, $dockerhost is going to be `local.docker`. If you are using [Docker for OSX](https://docs.docker.com/engine/installation/mac/#docker-for-mac), $dockerhost is going to be `localhost`. On Linux the containers bind to 0.0.0.0
 The wiki source directory gets mounted into the app containers under /usr/src/app
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-# this is a fig configuration file http://www.fig.sh
-# http://www.fig.sh/install.html
+# this is a docker-compose configuration file
+# https://docs.docker.com/compose/
 #
-# run fig up
+# execute: docker-compose up -d
 
 web:
   build: .
@@ -18,7 +18,7 @@ web:
 #
 # install the redis storage module by running
 #
-#     $ fig run web npm install wiki-storage-redis --save
+#     $ docker-compose run web npm install wiki-storage-redis --save
 #
 #webredis:
 #  build: .
@@ -39,7 +39,7 @@ web:
 #
 # install the couchdb storage module by running
 #
-#     $ fig run web npm install wiki-storage-couchdb --save
+#     $ docker-compose run web npm install wiki-storage-couchdb --save
 #
 #webcouch:
 #  build: .


### PR DESCRIPTION
fig was renamed/merged into docker-compose some time ago. This change
updates all references to 'fig' with the appropriate 'docker-compose'
command.
Additionally, using boot2docker on OSX is more or less a thing of the
past, thus this change mentions both DLite and the new(er) Docker for
Mac.