### PR TITLE
plugin upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "wiki-plugin-html": "0.2",
     "wiki-plugin-image": "0.2",
     "wiki-plugin-line": "0.3",
-    "wiki-plugin-map": "0.2",
+    "wiki-plugin-map": "0.3",
     "wiki-plugin-markdown": "0.2",
     "wiki-plugin-mathjax": "0.2",
     "wiki-plugin-metabolism": "0.2",
@@ -67,8 +67,8 @@
     "wiki-plugin-rollup": "0.2",
     "wiki-plugin-roster": "0.1",
     "wiki-plugin-scatter": "0.3",
-    "wiki-plugin-search": "0.0.9",
-    "wiki-plugin-transport": "0.0.8",
+    "wiki-plugin-search": "0.1",
+    "wiki-plugin-transport": "0.1",
     "wiki-plugin-video": "0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "wiki-plugin-rollup": "0.2",
     "wiki-plugin-roster": "0.1",
     "wiki-plugin-scatter": "0.3",
-    "wiki-plugin-search": "0.0.8",
-    "wiki-plugin-transport": "0.0.5",
+    "wiki-plugin-search": "0.0.9",
+    "wiki-plugin-transport": "0.0.8",
     "wiki-plugin-video": "0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I've published updates to four plugins.

```
transport 0.0.8
changes 0.2.4
html 0.2.4
search 0.0.9
```

This pull request updates package.json for the two that are specified to exact versions. I left alone the two that specify "0.2" thinking that this includes my updates. Am I right?

I'm open to advice as to how or if we should publish another version of wiki before wiki@next.
