### PR TITLE
Adding `~/.wiki/config.json` as an expected place to find config

### DIFF
--- a/cli.coffee
+++ b/cli.coffee
@@ -103,6 +103,7 @@ config = cc(argv,
   argv.config,
   'config.json',
   path.join(__dirname, '..', 'config.json'),
+  path.join(getUserHome(), '.wiki', 'config.json'),
   cc.env('wiki_'),
     port: 3000
     root: path.dirname(require.resolve('wiki-server'))


### PR DESCRIPTION
Adding `~/.wiki/config.json` as an expected place to find configuration, see #87