### PR TITLE
restart servers from plugin

### DIFF
--- a/farm.coffee
+++ b/farm.coffee
@@ -24,6 +24,16 @@ module.exports = exports = (argv) ->
   # Keep an array of servers that are currently active
   runningServers = []
 
+  # Listen for SIGUSR2 and restart wiki servers
+  process.on 'SIGUSR2', () ->
+    console.log 'Recieved SIGUSR2, restarting wiki servers'
+    oldHosts = hosts
+    hosts = {}
+    runningServers = []
+    setTimeout( () ->
+      oldHosts = null
+    , 5000)
+
   if argv.allowed
     allowedHosts = _.split(argv.allowed, ',')
     allowHost = (host) ->

--- a/farm.coffee
+++ b/farm.coffee
@@ -24,16 +24,6 @@ module.exports = exports = (argv) ->
   # Keep an array of servers that are currently active
   runningServers = []
 
-  # Listen for SIGUSR2 and restart wiki servers
-  process.on 'SIGUSR2', () ->
-    console.log 'Recieved SIGUSR2, restarting wiki servers'
-    oldHosts = hosts
-    hosts = {}
-    runningServers = []
-    setTimeout( () ->
-      oldHosts = null
-    , 5000)
-
   if argv.allowed
     allowedHosts = _.split(argv.allowed, ',')
     allowHost = (host) ->


### PR DESCRIPTION
This is part of an update to farm site management.

When the server receives a SIGUSR2 it will start using a new set of wiki servers for the farm, and dispose of the old ones.