### PR TITLE
use cluster exit event for restart

### DIFF
--- a/cli.coffee
+++ b/cli.coffee
@@ -145,9 +145,12 @@ if argv.test
   return
 
 if cluster.isMaster
-  cluster.on 'disconnect', ->
-    console.error 'disconnect'
-    cluster.fork()
+  cluster.on 'exit', (worker, code, signal) ->
+    if code is 0
+      console.log 'restarting wiki server'
+      cluster.fork()
+    else
+      console.error 'server unexpectly exitted, %d (%s)', worker.process.pid, signal || code
   cluster.fork()
 else
   if config.farm


### PR DESCRIPTION
A refinement of #98 

Here we use the cluster on exit event, and restart if the code is 0.