### PR TITLE
remove obsolete plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "wiki-plugin-data": "0.2",
     "wiki-plugin-factory": "0.2",
     "wiki-plugin-favicon": "0.2",
-    "wiki-plugin-federatedwiki": "0.2",
     "wiki-plugin-flagmatic": "^0.1.3",
     "wiki-plugin-force": "0.3",
     "wiki-plugin-future": "0.2",


### PR DESCRIPTION
This plugin remains a poorly named plugin that was quickly replaced by wiki-plugin-reference at the dawn of our experience writing plugins. We have now established that there are no pages in the visible federation that use this obsolete code.

![image](https://user-images.githubusercontent.com/12127/51443484-4df7b280-1c9e-11e9-82f8-63d12edc3d2b.png)

Once removed, we should archive the repo and deprecate the npm module.

https://help.github.com/articles/archiving-repositories/
https://docs.npmjs.com/cli/deprecate