### PR TITLE
Add socket.io to wiki instances in standalone and server farm mode.

### DIFF
--- a/cli.coffee
+++ b/cli.coffee
@@ -9,6 +9,9 @@
 # **cli.coffee** command line interface for the
 # Smallest-Federated-Wiki express server
 
+http = require('http')
+socketio = require('socket.io')
+
 path = require 'path'
 cluster = require 'cluster'
 
@@ -163,7 +166,10 @@ else
   else
     app = server(config)
     app.on 'owner-set', (e) ->
-      serv = app.listen app.startOpts.port, app.startOpts.host
+      server = http.Server(app)
+      app.io = socketio(server)
+
+      serv = server.listen app.startOpts.port, app.startOpts.host
       console.log "Federated Wiki server listening on", app.startOpts.port, "in mode:", app.settings.env
       if argv.security_type is './security'
         console.log 'INFORMATION : Using default security - Wiki will be read-only\n'

--- a/farm.coffee
+++ b/farm.coffee
@@ -13,6 +13,7 @@
 path = require 'path'
 
 http = require 'http'
+socketio = require 'socket.io'
 
 server = require 'wiki-server'
 
@@ -136,6 +137,7 @@ module.exports = exports = (argv) ->
       # Create a new server, add it to the list of servers, and
       # once it's ready send the request to it.
       local = server(newargv)
+      local.io = io
       hosts[incHost] = local
       runningServers.push(local)
 
@@ -151,4 +153,5 @@ module.exports = exports = (argv) ->
         local.emit 'running-serv', farmServ
         hosts[incHost](req, res)
 
+  io = socketio(farmServ)
   runningFarmServ = farmServ.listen(argv.port, argv.host)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "glob": "^7.1.4",
     "lodash": "^4.17.14",
     "optimist": "0.6",
+    "socket.io": "^2.2.0",
     "wiki-client": "^0.17.0",
     "wiki-plugin-activity": "^0.4.4",
     "wiki-plugin-assets": "^0.2.3",


### PR DESCRIPTION
This adds a socket.io reference in `app.io`. The target use case is that of communication with client side fedwiki plugins. Server-side plugins that want to make use of this are encouraged to use the event forwarding subsystem in wiki-server (an upcoming PR that depends on this being in place).

Questions:
* When a farm is restarted, non of the server side plugins will be initialized until the first request is made to a given site. For installs that use a whitelist, should we preemptively start the servers for all of the whitelisted sites?
* For farms in promiscuous mode, should we have an "always launch" list? If so, should both promiscuous and whitelisted installs use that parameter? We would default the value for whitelisted installs to be the list of whitelisted sites.
* Should there be an option for promiscuous installs to relaunch all sites that have ever been launched (or that have been previously launched and have had activity within the last X number of days)?

Without some change to how we handled farm installs, users that rely on server side plugins will need to be aware of whenever the farm restarts in order to minimize gaps in their server side processing.