### PR TITLE
Restrict creation of new wiki on demand

### DIFF
--- a/cli.coffee
+++ b/cli.coffee
@@ -46,8 +46,8 @@ argv = optimist
     alias     : 'f'
     describe  : 'Turn on the farm?'
   )
-  .options('restrict',
-    describe  : 'Only start wiki server for wiki that exist'
+  .options('allowed',
+    describe  : 'Either a coma seperated list of wiki, or * to only allow wiki which exist'
   )
   .options('admin',
     describe  : 'Wiki server administrator identity'

--- a/cli.coffee
+++ b/cli.coffee
@@ -46,6 +46,9 @@ argv = optimist
     alias     : 'f'
     describe  : 'Turn on the farm?'
   )
+  .options('restrict',
+    describe  : 'Only start wiki server for wiki that exist'
+  )
   .options('admin',
     describe  : 'Wiki server administrator identity'
   )

--- a/error-page.coffee
+++ b/error-page.coffee
@@ -1,0 +1,52 @@
+render = (title, errorText, messageText) ->
+    errorPage = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset=UTF-8>
+        <title>#{title}</title>
+        <style>
+        body {
+            background-image:  url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAMAAAC67D+PAAAABlBMVEXW2N7x8fFtFbdeAAAAKUlEQVR42jXKAQoAAAjCQPf/T8egCaEcbcxgA8MkjhcvsVmapBqJgb4PC6kAOLAu0ikAAAAASUVORK5CYII=');
+        }
+        section {
+            background-color: white;
+            width: 490px;
+            box-shadow: 2px 1px 4px rgba(0,0,0,0.2),
+                        inset 0px 0px 40px 0px pink;
+            padding: 30px;
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
+        }
+        header {
+            margin: 0px;
+        }
+        header h1:before {
+            content: '';
+            background: linear-gradient(135deg, #FE9B36, #507D1A);
+            width: 32px;
+            height: 32px;
+            display: inline-block;
+            margin-right: 10px;
+            margin-bottom: -6px;
+        }
+        header h1 {
+            margin-top: 0px;
+        }
+        </style>
+    </head>
+    <body>
+        <section id="nowiki">
+        <header>
+            <h1>Oops!</h1>
+            <p>#{errorText}</p>
+        </header>
+        <p>#{messageText}</p>
+        </section>
+    </body>
+    </html>
+    """
+
+module.exports = {render}

--- a/farm.coffee
+++ b/farm.coffee
@@ -20,6 +20,8 @@ server = require 'wiki-server'
 
 _ = require('lodash')
 
+errorPage = require './error-page'
+
 module.exports = exports = (argv) ->
   # Map incoming hosts to their wiki's port
   hosts = {}
@@ -117,7 +119,8 @@ module.exports = exports = (argv) ->
       # check that request is for an allowed host
       unless allow(incHost)
         res.statusCode = 400
-        res.end('Invalid host')
+        errorText = errorPage.render('Requested Wiki Does Not Exist','The wiki you are trying to access does not exist.','')
+        res.end(errorText)
         return
 
 

--- a/farm.coffee
+++ b/farm.coffee
@@ -26,38 +26,35 @@ module.exports = exports = (argv) ->
   # Keep an array of servers that are currently active
   runningServers = []
 
-  # if farm is restricting new wiki creation, keep a list of existing wiki within the farm
-  existingWiki = []
-
-  if argv.restrict
-    wikiDir = if argv.data
-      argv.data
-    else
-      path.join(argv.root, 'data')
-    # 
-    existingWiki = fs.readdirSync(wikiDir, {withFileTypes: true})
-      .filter (item) -> item.isDirectory()
-      .map (item) -> item.name
-
-    # we don't want to have to restart wiki each time a new wiki is added, so watch for new wiki directories
-    watcher = chokidar.watch wikiDir, {
-      persistent: true
-      ignoreInitial: true
-      depth: 0
-    }
-
-    watcher
-      .on('addDir', (newWiki) -> 
-        newWiki = path.basename(newWiki)
-        existingWiki.push(newWiki)
-      .on('unlinkDir', (delWiki) -> 
-        delWiki = path.basename(delWiki)
-        _.pull(existingWiki, delWiki)
-
-
-
   if argv.allowed
-    allowedHosts = _.split(argv.allowed, ',')
+    if argv.allowed is '*'
+      # we will allow any wiki which we have a directory exists
+      wikiDir = argv.data
+      allowedHosts = fs.readdirSync(wikiDir, {withFileTypes: true})
+        .filter (item) -> item.isDirectory()
+        .map (item) -> item.name
+      
+      # watch for new wiki directories being created (or deleted), and keep allowedHosts up to date
+      watcher = chokidar.watch wikiDir, {
+        persistent: true
+        ignoreInitial: true
+        depth: 0
+      }
+
+      watcher
+        .on 'addDir', (newWiki) ->
+          newWiki = path.basename(newWiki)
+          allowedHosts.push(newWiki)
+        .on 'unlinkDir', (delWiki) ->
+          delWiki = path.basename(delWiki)
+          _.pull(allowedHosts, delWiki)
+
+    else
+      # we have a list of wiki that are allowed
+      allowedHosts = argv.allowed
+        .split ','                      # split up the coma seperated list of allowed hosts
+        .map (item) -> item.trim()      # trim any whitespace padding from the items in the list
+
     allowHost = (host) ->
       hostDomain = _.split(host, ':')[0]
       if _.includes(allowedHosts, hostDomain)
@@ -82,9 +79,6 @@ module.exports = exports = (argv) ->
     allowDomain = () -> true
 
   allow = (host) ->
-    # if a farm is restricting new wiki we will only let the wiki server start if directory for the wiki already exists
-    if argv.restrict and !existingWiki.includes(host)
-      return false
     # wikiDomains and allowed should both be optional
     if argv.allowed and allowHost(host)
       return true

--- a/farm.coffee
+++ b/farm.coffee
@@ -82,19 +82,31 @@ module.exports = exports = (argv) ->
 
   allow = (host) ->
     # wikiDomains and allowed should both be optional
-    if argv.allowed and allowHost(host)
-      return true
-    else
-      if argv.wikiDomains and allowDomain(host)
+    if argv.allowed
+      if allowHost(host)
+        # host is in the allowed list
+        if argv.wikiDomains
+          if allowDomain(host)
+            # host is within a defined wikiDomain
+            return true
+          else
+            # while host is in the allowed list, it is not within an allowed domain
+            return false
+        return true
+      else
+        # host is not within the allowed list
+        return false
+  
+    if argv.wikiDomains
+      if allowDomain(host)
         # host is within a defined wikiDomain
         return true
       else
-        if argv.wikiDomains or argv.allowed
-          # host is in the list of allowed hosts
-          return false
-        else
-          # neither wikiDomain or allowed are configured
-          return true
+        # host is not within a defined wikiDomain
+        return false
+
+    # neither wikiDomain or allowed are configured
+    return true
 
 
   farmServ = http.createServer (req, res) ->

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,6 +242,119 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.1.tgz",
+          "integrity": "sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==",
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        },
+        "picomatch": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
+          "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA=="
+        },
+        "readdirp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+          "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+          "requires": {
+            "picomatch": "^2.0.4"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "client-sessions": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/client-sessions/-/client-sessions-0.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "chokidar": "^3.3.0",
     "coffeescript": "^2.4.1",
     "config-chain": "^1.1.12",
     "glob": "^7.1.4",
@@ -93,6 +94,6 @@
     "url": "https://github.com/fedwiki/wiki/issues"
   },
   "engines": {
-    "node": ">=8.x"
+    "node": ">=10.10.0"
   }
 }


### PR DESCRIPTION
Here we added a variation to `allowed` using the value `*`, to indicate that a wiki server will be started if a directory exists for the wiki.

A nicer looking error page is also added for when a wiki that is not allowed is accessed.
![Screenshot 2019-11-16 at 12 03 18](https://user-images.githubusercontent.com/1552489/68992860-1da28580-0869-11ea-8876-48cc91de012a.png)

`allow(host)` is also reworked for the combinations of `allowed` and `wikiDomains`. 
