### PR TITLE
Bytebeat Plugin judged useless

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "wiki-plugin-assets": "^0.2.4",
     "wiki-plugin-audio": "^0.1.8",
     "wiki-plugin-bars": "^0.3.2",
-    "wiki-plugin-bytebeat": "^0.2.5",
     "wiki-plugin-calculator": "^0.2.4",
     "wiki-plugin-calendar": "^0.2.6",
     "wiki-plugin-changes": "^0.3.2",


### PR DESCRIPTION
This plugin dates back to the earliest days of federated wiki when it might have served some useful purpose for chiptune inspired composers. I corresponded with Kragen suggesting that such composers might find federated wiki useful but did not even make his list of bytebeat innovations.

https://en.wikipedia.org/wiki/Chiptune
http://canonical.org/~kragen/bytebeat/

I recommend this plugin's repo remain and be available through Plugmatic for anyone who would want to explore this bit of wiki history. But there is no need to have it remain as part of any recommended install.