### PR TITLE
making wikiDomains consistent

### DIFF
--- a/farm.coffee
+++ b/farm.coffee
@@ -59,22 +59,26 @@ module.exports = exports = (argv) ->
         .map (item) -> item.trim()      # trim any whitespace padding from the items in the list
 
     allowHost = (host) ->
-      hostDomain = _.split(host, ':')[0]
-      if _.includes(allowedHosts, hostDomain)
+      hostDomain = host.split(':')[0]
+      if allowedHosts.includes(hostDomain)
         return true
       else
         return false
 
   if argv.wikiDomains
-    wikiDomains = _.keys(argv.wikiDomains)
+    wikiDomains = Object.keys(argv.wikiDomains)
     inWikiDomain = ''
     allowDomain = (host) ->
-      hostDomain = _.split(host, ':')[0]
-      inWikiDomain = ''
-      _.each wikiDomains, (domain) ->
-        if _.endsWith hostDomain, domain
-          inWikiDomain = domain
-      if inWikiDomain
+      hostDomain = host.split(':')[0]
+      possibleWikiDomain = []
+      wikiDomains.forEach((domain) ->
+        if hostDomain.endsWith(domain)
+          possibleWikiDomain.push(domain)
+        )
+      if possibleWikiDomain
+        inWikiDomain = possibleWikiDomain.reduce((a, b) ->
+          if a.length > b.length then a else b
+        )
         return true
       else
         return false

--- a/farm.coffee
+++ b/farm.coffee
@@ -75,7 +75,7 @@ module.exports = exports = (argv) ->
         if hostDomain.endsWith(domain)
           possibleWikiDomain.push(domain)
         )
-      if possibleWikiDomain
+      if possibleWikiDomain.length > 0
         inWikiDomain = possibleWikiDomain.reduce((a, b) ->
           if a.length > b.length then a else b
         )


### PR DESCRIPTION
It was spotted that the ordering of wikiDomain parameters matters. 

This change will use the longest possible wikiDomain, rather than the first found.