### PR TITLE
Initialise Nix flake with nixosModule/vmTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ data
 node_modules
 *.log
 
+# Nix build results
+*result*
+

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  config,
+  dream2nix,
+  ...
+}: {
+  imports = [
+    dream2nix.modules.dream2nix.nodejs-package-lock-v3
+    dream2nix.modules.dream2nix.nodejs-granular-v3
+  ];
+
+  nodejs-package-lock-v3.packageLockFile = ./package-lock.json;
+
+  deps = {nixpkgs, ...}: {
+    inherit
+      (nixpkgs)
+      fetchFromGitHub
+      stdenv
+      ;
+  };
+
+  name = "wiki";
+  version = (builtins.fromJSON (builtins.readFile ./package.json)).version;
+
+  mkDerivation = {
+    src = ./.;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,148 @@
+{
+  "nodes": {
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "purescript-overlay": "purescript-overlay",
+        "pyproject-nix": "pyproject-nix"
+      },
+      "locked": {
+        "lastModified": 1700037880,
+        "narHash": "sha256-gD6a+aSG1PEiBvCcE5/4fz1zqdPkDC/Xj073daPIgv0=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "8db4cb11214ec2c415c85632461da0083f3b0a7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1695837737,
+        "narHash": "sha256-KcqmJ5hNacLuE7fkz5586kp/vt4NLo6+Prq3DMgrxpQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "517501bcf14ae6ec47efd6a17dda0ca8e6d866f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1696022621,
+        "narHash": "sha256-eMjFmsj2G1E0Q5XiibUNgFjTiSz0GxIeSSzzVdoN730=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "047c7933abd6da8aa239904422e22d190ce55ead",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699067645,
+        "narHash": "sha256-SJOEPVFARVfS0qQQqbnGywt8uOZMmlV1PazQtGNNCfQ=",
+        "owner": "adisbladis",
+        "repo": "pyproject.nix",
+        "rev": "56b5a6ae1ac63a0a3a044d602a3b5d09a5d10dc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dream2nix": "dream2nix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "dream2nix",
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688610262,
+        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "FedWiki Client and Server";
+
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.follows = "dream2nix/nixpkgs";
+  };
+
+  outputs = inputs @ { self, flake-parts, dream2nix, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        flake-parts.flakeModules.easyOverlay
+      ];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      flake = {
+        nixosModule = { pkgs, lib, config, ... }: {
+          imports = [ ./nix/wiki-module.nix ];
+          nixpkgs.overlays = [ self.overlays.default ];
+        };
+      };
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        overlayAttrs = config.packages // config.legacyPackages;
+        checks = {
+          wiki = pkgs.callPackage ./nix/wiki-vmtest.nix { nixosModule = self.nixosModule; };
+        };
+        packages = rec {
+          wiki = default;
+          default = dream2nix.lib.evalModules {
+            packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
+            modules = [
+              ./default.nix
+              {
+                paths = {
+                  projectRoot = ./.;
+                  projectRootFile = "flake.nix";
+                  package = ./.;
+                };
+              }
+            ];
+          };
+        };
+      };
+  };
+}

--- a/nix/wiki-module.nix
+++ b/nix/wiki-module.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.wiki;
+in {
+  options.services.wiki = {
+    enable = lib.mkEnableOption "wiki";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.wiki;
+      defaultText = "pkgs.wiki";
+      description = ''
+        Which wiki package to use.
+      '';
+    };
+    dataDir = lib.mkOption {
+      default = "/var/lib/wiki";
+      type = lib.types.str;
+    };
+    settings = lib.mkOption {
+      default = {};
+      defaultText = "{}";
+      description = ''
+        A Nix attribute set of JSON configuration options to pass to the wiki node server
+      '';
+      type = lib.types.attrs;
+    };
+  };
+  config = let
+    configJson = ((pkgs.formats.json {}).generate "wiki-settings.json" cfg.settings);
+  in lib.mkIf cfg.enable {
+    systemd = {
+      services.wiki = {
+        description = "Federated Wiki NodeJS Server";
+        wantedBy = [ "multi-user.target" ];
+        wants = [ "network-online.target" ];
+        after = [ "network-online.target" ];
+        environment.HOME = "${cfg.dataDir}";
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${pkgs.bash}/bin/bash -c '${lib.getExe cfg.package} --config ${builtins.trace (configJson.outPath) configJson}'";
+          Restart = "always";
+          DynamicUser = true;
+          StateDirectory = baseNameOf cfg.dataDir;
+        };
+      };
+    };
+  };
+}
+

--- a/nix/wiki-vmtest.nix
+++ b/nix/wiki-vmtest.nix
@@ -1,0 +1,37 @@
+{ nixosTest, pkgs, nixosModule }:
+let
+  port = 6969;
+in
+nixosTest {
+  name = "wiki";
+  nodes = {
+    client = { ... }: {
+      environment.systemPackages = with pkgs; [ curl ];
+    };
+    server = { config, ... }: {
+      imports = [ nixosModule ];
+      networking.firewall.allowedTCPPorts = [ port ];
+      services.wiki = {
+        enable = true;
+        settings = {
+          port = toString port;
+          host = "0.0.0.0";
+          security_legacy = "false";
+          home = "test-string";
+        };
+      };
+    };
+  };
+  testScript = ''
+    start_all()
+    client.wait_for_unit("multi-user.target")
+    server.wait_for_unit("multi-user.target")
+
+    server.wait_for_unit("wiki.service")
+    server.wait_for_open_port(${toString port})
+
+    with subtest("Check that the wiki webserver can be reached."):
+        client.succeed("curl -sSf http:/server:${toString port} | grep -q 'test-string'")
+  '';
+}
+


### PR DESCRIPTION
Initialises a Nix flake that contains a nixosModule that can be included and used in NixOS like

```nix
{
  services.wiki = {
    enable = true;
    settings = {
      port = 6969;
      host = "0.0.0.0";
      security_legacy = "false";
      home = "test-string";
    };
  };
}
```

This is then tested in the VM Test that spins up a client and server VM and tests that the `home` is reachable, which can be built like

`nix flake check github:matthewcroughan/wiki -L`

To build the wiki server from this PR you can run `nix build github:matthewcroughan/wiki -L`
To run the wiki server from this PR you can run `nix run github:matthewcroughan/wiki -L`

Once merged, building/running is as simple as `nix build` or `nix run` from the root of this repo, which will use the `default` attribute of the `flake.nix`