### PR TITLE
Add warning for localhost subdomain limitations in farm mode

### DIFF
--- a/farm.js
+++ b/farm.js
@@ -215,6 +215,14 @@ module.exports = exports = function (argv) {
         newargv.wiki_domain = inWikiDomain
       }
 
+      // Warn about localhost subdomain limitations in farm mode
+      const hostDomain = incHost.split(':')[0]
+      if (hostDomain.endsWith('.localhost')) {
+        console.log('WARNING: Localhost subdomains may cause authentication issues in farm mode.')
+        console.log('  Consider using *.localtest.me domains for reliable local development.')
+        console.log('  See: https://tools.ietf.org/html/rfc6761#section-6.3\n')
+      }
+
       // Create a new server, add it to the list of servers, and
       // once it's ready send the request to it.
       const local = server(newargv)


### PR DESCRIPTION
# Warn about localhost subdomain issues in farm mode

Authentication breaks when using localhost subdomains like `test.localhost` in farm mode. Works fine on `localhost`, fails on `test.localhost` with confusing errors.

The problem: browsers can't share cookies between `localhost` and subdomains due to RFC 6761 restrictions. Same setup works great with `*.localtest.me` domains.

This adds a simple warning when someone tries to use localhost subdomains:

```
WARNING: Localhost subdomains may cause authentication issues in farm mode.
  Consider using *.localtest.me domains for reliable local development.
  See: https://tools.ietf.org/html/rfc6761#section-6.3
```

Saves developers time debugging authentication failures and points them to a working solution.