### PR TITLE
Remove lodash dependency

### DIFF
--- a/farm.js
+++ b/farm.js
@@ -19,8 +19,6 @@ const http = require('http')
 
 const server = require('wiki-server')
 
-const _ = require('lodash')
-
 const errorPage = require('./error-page')
 
 module.exports = exports = function (argv) {
@@ -54,7 +52,9 @@ module.exports = exports = function (argv) {
         })
         .on('unlinkDir', function (delWiki) {
           delWiki = path.basename(delWiki)
-          _.pull(allowedHosts, delWiki)
+          // remove deleted wiki directory from the list of allowed wiki
+          allowedHosts.splice(allowedHosts.indexOf(delWiki), 1)
+          // TODO: if wiki server is already running, it needs to be stopped, if that is even possible.
         })
     } else {
       // we have a list of wiki that are allowed
@@ -211,7 +211,7 @@ module.exports = exports = function (argv) {
 
       // apply wiki domain configuration, if defined
       if (inWikiDomain) {
-        newargv = _.assignIn(newargv, newargv.wikiDomains[inWikiDomain])
+        newargv = Object.assign({}, newargv, newargv.wikiDomains[inWikiDomain])
         newargv.wiki_domain = inWikiDomain
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "chokidar": "^4.0.3",
         "coffeescript": "^2.6.0",
         "config-chain": "^1.1.13",
-        "lodash": "^4.17.21",
         "minimist": "^1.2.7",
         "wiki-client": "^0.31.1",
         "wiki-plugin-activity": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "chokidar": "^4.0.3",
     "coffeescript": "^2.6.0",
     "config-chain": "^1.1.13",
-    "lodash": "^4.17.21",
     "minimist": "^1.2.7",
     "wiki-client": "^0.31.1",
     "wiki-plugin-activity": "^0.7.0",


### PR DESCRIPTION
Remove lodash dependency in favor of native methods

`_.pull()` is replaced with Array `splice()`, and 
`_.assignIn()` is replaced with `Object.assign()`.