### PR TITLE
Preserve non-default port in farm site URLs

### DIFF
--- a/farm.js
+++ b/farm.js
@@ -137,9 +137,13 @@ export function farm(argv) {
   }
 
   var farmServ = http.createServer(function (req, res) {
-    let incHost
+    let incHost, incPort
     if (req.headers?.host) {
-      incHost = req.headers.host.split(':')[0]
+      const hostParts = req.headers.host.split(':')
+      incHost = hostParts[0]
+      if (/^\d+$/.test(hostParts[1]) && Number(hostParts[1]) <= 65535) {
+        incPort = hostParts[1]
+      }
     } else {
       res.statusCode = 400
       res.end('Missing host header')
@@ -206,7 +210,8 @@ export function farm(argv) {
       newargv.data = argv.data
         ? path.join(argv.data, incHost.split(':')[0])
         : path.join(argv.root, 'data', incHost.split(':')[0])
-      newargv.url = `http://${incHost}`
+      const sitePort = incPort && incPort !== '80' && incPort !== '443' ? `:${incPort}` : ''
+      newargv.url = `http://${incHost}${sitePort}`
 
       // apply wiki domain configuration, if defined
       if (inWikiDomain) {


### PR DESCRIPTION
Farm mode strips the port from the incoming Host header before building each site's `url` option. A farm running on a non-default port (e.g. `http://site.localtest.me:8092` for local development) spawns sites that think their URL is `http://site.localtest.me`, so OAuth callbacks and trusted origins derived from `argv.url` point at port 80 and sign-on only works on the standard port.

This keeps the port when building `newargv.url`. `incHost` stays portless, so the allowed/wikiDomains checks and the data directory paths are unchanged. An explicit `:80` or `:443` is still dropped, same as defaultargs does for a standalone server, and anything that isn't a valid port number is ignored rather than passed into the URL. A farm on the standard port sees no change at all, since browsers omit the default port from the Host header.

This is also how the farm originally worked: farm.coffee kept the port in `incHost` and only stripped it for the data path (the `incHost.split(':')[0]` there is a leftover). The strip at the top came in with the restrict-farm-growth work (c655d0f) so hosts could be compared against data directory names, and those comparisons still see a portless host.

Tested with `node --check` and `prettier --check`; eslint output is unchanged. Running a farm with `--port 8092`, the spawned site's `url` now carries the port.

Companion change in [wiki-security-social](https://github.com/fedwiki/wiki-security-social/pull/4) opens the sign-on dialog on the browser's port; together they make farm sign-on work on non-default http ports (extremely useful in local development or non-standard networking setups)
